### PR TITLE
Add mock navigation items

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -3,3 +3,6 @@
 - Updated README with project sections.
 - Created WORKLOG to track development actions.
 - Fixed ESLint warnings in router configuration.
+2025-06-13
+- Implemented mock navigation items with icons and descriptions in the navigation drawer.
+- Ran pnpm lint and type-check to ensure code quality.

--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -17,9 +17,17 @@
         </template>
       </v-app-bar>
 
-      <v-navigation-drawer v-model="drawer" :locations="left">
-        <v-list>
-          <v-list-item title="Navigation drawer" />
+      <v-navigation-drawer v-model="drawer" location="left">
+        <v-list density="comfortable">
+          <template v-for="(item, i) in navigationItems" :key="i">
+            <v-divider v-if="item.separator" />
+            <v-list-item
+              v-else
+              :prepend-icon="item.icon"
+              :subtitle="item.subtitle"
+              :title="item.title"
+            />
+          </template>
         </v-list>
       </v-navigation-drawer>
 
@@ -54,4 +62,19 @@
     vuetifyTheme.global.name.value
       = vuetifyTheme.global.current.value.dark ? 'light' : 'dark'
   }
+
+  /**
+   * Navigation drawer items.
+   * Each entry has a Material Design icon, a title, and a short description
+   * shown as the subtitle. Separators are represented with `separator: true`.
+   */
+  const navigationItems = [
+    { icon: 'mdi-account-group', title: 'People', subtitle: 'Manage team members' },
+    { icon: 'mdi-account-multiple-outline', title: 'Teams', subtitle: 'Manage teams' },
+    { icon: 'mdi-clipboard-check-outline', title: 'Tasks', subtitle: 'Manage tasks' },
+    { icon: 'mdi-cash-multiple', title: 'Budget', subtitle: 'Manage budget' },
+    { separator: true },
+    { icon: 'mdi-book-open-page-variant-outline', title: 'References', subtitle: 'Manage reference data' },
+    { icon: 'mdi-account-cog-outline', title: 'Users', subtitle: 'Manage system users' },
+  ]
 </script>


### PR DESCRIPTION
## Summary
- add icons and subtitles to navigation drawer
- document the addition in WORKLOG

## Testing
- `pnpm lint`
- `pnpm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_684bf462db4c83258127d7df6eb64673