### PR TITLE
Add pages and routing for nav drawer items

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pnpm build
 ```
 
 ## Examples
-After running the development server, open `http://localhost:3000` in your browser to see the default welcome page. Edit components in `src/` to begin customizing the application.
+After running the development server, open `http://localhost:3000` in your browser. The navigation drawer links (Home, People, Teams, Tasks, Budget, References, and Users) each lead to a dedicated page that you can further extend. Edit components in `src/` to continue customizing the application.
 
 ## Contributing Guidelines
 1. Fork the repository and create feature branches for your work.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -6,3 +6,8 @@
 2025-06-13
 - Implemented mock navigation items with icons and descriptions in the navigation drawer.
 - Ran pnpm lint and type-check to ensure code quality.
+
+2025-06-13
+- Added dedicated pages for all navigation drawer items and updated the drawer links.
+- Introduced Home item leading to the main page.
+- Updated README examples section and ran pnpm lint and type-check.

--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -8,8 +8,11 @@
         </template>
         <v-app-bar-title>Fulcrum</v-app-bar-title>
         <template #append>
-          <v-btn :icon="vuetifyTheme.global.current.value.dark ? 'mdi-weather-night' : 'mdi-weather-sunny'" slim
-            @click="toggleTheme" />
+          <v-btn
+            :icon="vuetifyTheme.global.current.value.dark ? 'mdi-weather-night' : 'mdi-weather-sunny'"
+            slim
+            @click="toggleTheme"
+          />
           <v-btn icon="mdi-dots-vertical" />
         </template>
       </v-app-bar>
@@ -20,9 +23,11 @@
             <v-divider v-if="item.separator" />
             <v-list-item
               v-else
+              link
               :prepend-icon="item.icon"
               :subtitle="item.subtitle"
               :title="item.title"
+              :to="item.to"
             />
           </template>
         </v-list>
@@ -38,19 +43,19 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue'
-import { useTheme } from 'vuetify'
+  import { ref } from 'vue'
+  import { useTheme } from 'vuetify'
 
-/**
- * Reactive state for the navigation drawer.
- */
-const drawer = ref(false)
+  /**
+   * Reactive state for the navigation drawer.
+   */
+  const drawer = ref(false)
 
-/**
- * Access Vuetify's theme instance so we can switch between light and dark
- * modes.
- */
-const vuetifyTheme = useTheme()
+  /**
+   * Access Vuetify's theme instance so we can switch between light and dark
+   * modes.
+   */
+  const vuetifyTheme = useTheme()
 
   /**
    * Toggle between light and dark themes.
@@ -66,12 +71,13 @@ const vuetifyTheme = useTheme()
    * shown as the subtitle. Separators are represented with `separator: true`.
    */
   const navigationItems = [
-    { icon: 'mdi-account-group', title: 'People', subtitle: 'Manage team members' },
-    { icon: 'mdi-account-multiple-outline', title: 'Teams', subtitle: 'Manage teams' },
-    { icon: 'mdi-clipboard-check-outline', title: 'Tasks', subtitle: 'Manage tasks' },
-    { icon: 'mdi-cash-multiple', title: 'Budget', subtitle: 'Manage budget' },
+    { icon: 'mdi-home', title: 'Home', subtitle: 'Return to home page', to: '/' },
+    { icon: 'mdi-account-group', title: 'People', subtitle: 'Manage team members', to: '/people' },
+    { icon: 'mdi-account-multiple-outline', title: 'Teams', subtitle: 'Manage teams', to: '/teams' },
+    { icon: 'mdi-clipboard-check-outline', title: 'Tasks', subtitle: 'Manage tasks', to: '/tasks' },
+    { icon: 'mdi-cash-multiple', title: 'Budget', subtitle: 'Manage budget', to: '/budget' },
     { separator: true },
-    { icon: 'mdi-book-open-page-variant-outline', title: 'References', subtitle: 'Manage reference data' },
-    { icon: 'mdi-account-cog-outline', title: 'Users', subtitle: 'Manage system users' },
+    { icon: 'mdi-book-open-page-variant-outline', title: 'References', subtitle: 'Manage reference data', to: '/references' },
+    { icon: 'mdi-account-cog-outline', title: 'Users', subtitle: 'Manage system users', to: '/users' },
   ]
 </script>

--- a/fe/src/pages/budget.vue
+++ b/fe/src/pages/budget.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-container>
+    <h1 class="text-h4">Budget</h1>
+    <p>Manage budget.</p>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+</script>

--- a/fe/src/pages/people.vue
+++ b/fe/src/pages/people.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-container>
+    <h1 class="text-h4">People</h1>
+    <p>Manage team members.</p>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+</script>

--- a/fe/src/pages/references.vue
+++ b/fe/src/pages/references.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-container>
+    <h1 class="text-h4">References</h1>
+    <p>Manage reference data.</p>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+</script>

--- a/fe/src/pages/tasks.vue
+++ b/fe/src/pages/tasks.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-container>
+    <h1 class="text-h4">Tasks</h1>
+    <p>Manage tasks.</p>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+</script>

--- a/fe/src/pages/teams.vue
+++ b/fe/src/pages/teams.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-container>
+    <h1 class="text-h4">Teams</h1>
+    <p>Manage teams.</p>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+</script>

--- a/fe/src/pages/users.vue
+++ b/fe/src/pages/users.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-container>
+    <h1 class="text-h4">Users</h1>
+    <p>Manage system users.</p>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+</script>

--- a/fe/src/typed-router.d.ts
+++ b/fe/src/typed-router.d.ts
@@ -19,5 +19,11 @@ declare module 'vue-router/auto-routes' {
    */
   export interface RouteNamedMap {
     '/': RouteRecordInfo<'/', '/', Record<never, never>, Record<never, never>>,
+    '/budget': RouteRecordInfo<'/budget', '/budget', Record<never, never>, Record<never, never>>,
+    '/people': RouteRecordInfo<'/people', '/people', Record<never, never>, Record<never, never>>,
+    '/references': RouteRecordInfo<'/references', '/references', Record<never, never>, Record<never, never>>,
+    '/tasks': RouteRecordInfo<'/tasks', '/tasks', Record<never, never>, Record<never, never>>,
+    '/teams': RouteRecordInfo<'/teams', '/teams', Record<never, never>, Record<never, never>>,
+    '/users': RouteRecordInfo<'/users', '/users', Record<never, never>, Record<never, never>>,
   }
 }


### PR DESCRIPTION
## Summary
- create simple pages for each nav drawer entry
- wire the drawer items to routes and add a home link
- update typed router definitions
- note new navigation in the README
- log today's work in WORKLOG

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_684c02906ab48325977a255a21c7103a