### PR TITLE
Add GraphQL health query

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ query {
 }
 ```
 
+To verify the API server is ready, send the health query:
+
+```graphql
+query {
+  health
+}
+```
+
 ## Contributing Guidelines
 1. Fork the repository and create feature branches for your work.
 2. Run `pnpm run lint` in `fe` and `npm run lint` in `be` before opening a pull request.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -31,3 +31,7 @@
 - Added environment variable override mapping and related tests.
 - Updated README with override instructions.
 - Ran npm run lint and npm test.
+2025-06-13
+- Added health GraphQL query and resolver returning readiness state.
+- Documented usage in README and added health tests.
+- Ran npm install, lint and tests.

--- a/be/src/schema.ts
+++ b/be/src/schema.ts
@@ -18,6 +18,7 @@ export const typeDefs = gql`
 
   type Query {
     me: User
+    health: Boolean!
   }
 
   type Mutation {
@@ -38,6 +39,7 @@ export const resolvers = {
       __: unknown,
       { user }: { user?: { id: string; email: string } },
     ) => user || null,
+    health: () => Boolean(db),
   },
   Mutation: {
     async register(
@@ -97,7 +99,10 @@ export const resolvers = {
   },
 };
 
-/** Assign database instance to resolvers */
+/**
+ * Assign the active database instance used by resolvers.
+ * The health query relies on this value to determine readiness.
+ */
 export function setDb(database: Database) {
   db = database;
 }

--- a/be/tests/health.test.ts
+++ b/be/tests/health.test.ts
@@ -1,0 +1,28 @@
+import type { Application } from 'express';
+import request from 'supertest';
+import { createApp } from '../src/index';
+import fs from 'fs';
+import path from 'path';
+
+let app: Application;
+
+beforeAll(async () => {
+  const dbFile = path.join(__dirname, 'health-db.json');
+  if (fs.existsSync(dbFile)) fs.unlinkSync(dbFile);
+  const config = require('../src/config').default;
+  config.dbFile = dbFile;
+  ({ app } = await createApp());
+});
+
+afterAll(() => {
+  // cleanup
+});
+
+describe('Health query', () => {
+  test('returns true when server is ready', async () => {
+    const res = await request(app).post('/graphql').send({
+      query: `query { health }`,
+    });
+    expect(res.body.data.health).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- expose `health` query in API schema
- implement resolver checking readiness
- document query usage in README
- add unit test for the health query
- log work in WORKLOG

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c24f54cbc8325b3f609bf5b91371d