### PR TITLE
Add backend readiness indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ query {
 }
 ```
 
+The Vue application automatically checks this endpoint on load and shows the
+backend status in the footer.
+
 Authentication mutations return both a short-lived access token and a long-lived
 `refreshToken`. Use the `refreshToken` mutation with the provided refresh token
 to obtain a new access token. Call `logout` with the refresh token to invalidate

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -38,3 +38,7 @@
 - Added health GraphQL query and resolver returning readiness state.
 - Documented usage in README and added health tests.
 - Ran npm install, lint and tests.
+2025-06-13
+- Display backend readiness in the front-end footer using the health query.
+- Updated README with footer description.
+- Ran pnpm lint, npm run lint and npm test.

--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -17,10 +17,10 @@
         </template>
       </v-app-bar>
 
-      <v-navigation-drawer v-model="drawer" location="left" :elevation="2">
+      <v-navigation-drawer v-model="drawer" :elevation="2" location="left">
         <v-list density="compact">
           <template v-for="(item, i) in navigationItems" :key="i">
-            <v-divider v-if="item.separator" :thickness="3"  />
+            <v-divider v-if="item.separator" :thickness="3" />
             <v-list-item
               v-else
               link

--- a/fe/src/components/AppFooter.vue
+++ b/fe/src/components/AppFooter.vue
@@ -22,13 +22,19 @@
       class="text-caption text-disabled"
       style="position: absolute; right: 16px;"
     >
-      &copy; {{ (new Date()).getFullYear() }} <span class="d-none d-sm-inline-block">Radek Zitek</span>
+      <span :class="ready ? 'text-success' : 'text-error'">
+        Backend: {{ ready ? 'ready' : 'offline' }}
+      </span>
+      &nbsp;|&nbsp;© {{ (new Date()).getFullYear() }}
+      <span class="d-none d-sm-inline-block">Radek Zitek</span>
 
     </div>
   </v-footer>
 </template>
 
 <script setup lang="ts">
+  import { onMounted, ref } from 'vue'
+
   const items = [
     {
       title: 'Vuetify Documentation',
@@ -36,6 +42,26 @@
       href: 'https://vuetifyjs.com/',
     },
   ]
+
+  /** Indicates whether the backend server is ready. */
+  const ready = ref<boolean | null>(null)
+
+  /**
+   * Query the backend health endpoint and update the readiness state.
+   */
+  onMounted(async () => {
+    try {
+      const res = await fetch('/graphql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: 'query{ health }' }),
+      })
+      const json = await res.json()
+      ready.value = json?.data?.health === true
+    } catch {
+      ready.value = false
+    }
+  })
 </script>
 
 <style scoped lang="sass">


### PR DESCRIPTION
## Summary
- show backend readiness in AppFooter
- mention footer health check in README
- record worklog entry
- linted frontend auto-adjusted App.vue formatting

## Testing
- `pnpm lint` in `fe`
- `npm run lint` in `be`
- `npm test` in `be`


------
https://chatgpt.com/codex/tasks/task_e_684c26fa72788325ad949155584a4797