### PR TITLE
Add dev proxy for GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Start a development server with hot reloading:
 ```bash
 pnpm dev
 ```
+The dev server proxies GraphQL requests on `/graphql` to `http://localhost:4000`,
+so make sure the back end is running during development.
 
 Run the GraphQL API in development mode (uses ts-node):
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -38,3 +38,8 @@
 - Added health GraphQL query and resolver returning readiness state.
 - Documented usage in README and added health tests.
 - Ran npm install, lint and tests.
+2025-06-13
+- Configured Vite dev server proxy to backend GraphQL on port 4000.
+- Updated README with proxy note.
+- Ran pnpm install, lint, and npm install, lint, test.
+

--- a/fe/vite.config.mts
+++ b/fe/vite.config.mts
@@ -84,6 +84,13 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    proxy: {
+      // Proxy API requests during development to the backend GraphQL server
+      '/graphql': {
+        target: 'http://localhost:4000',
+        changeOrigin: true,
+      },
+    },
   },
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
## Summary
- set up a development proxy in Vite for `/graphql`
- document proxy behaviour in README
- record work in WORKLOG

## Testing
- `pnpm lint`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c27400f688325b427158c4bd2722d