### PR TITLE
Implement authentication dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The back end reads settings using the [`config`](https://www.npmjs.com/package/c
 ## Examples
 After running the development server, open `http://localhost:3000` in your browser. The navigation drawer links (Home, People, Teams, Tasks, Budget, References, and Users) each lead to a dedicated page that you can further extend. Edit components in `src/` to continue customizing the application.
 
+The app bar contains a triple-dot menu that adapts based on authentication state. When logged out it offers **Login**, **Register**, and **Password Reset** actions. Once logged in the menu switches to **Profile**, **Change Password**, and **Logout**.
+
 For the API you can send the following query using `curl` or a GraphQL client. You can also override configuration values on the fly:
 
 ```bash

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -45,3 +45,8 @@
 - Display backend readiness in the front-end footer using the health query.
 - Updated README with footer description.
 - Ran pnpm lint, npm run lint and npm test.
+2025-06-13
+- Added authentication menu with two states using Pinia.
+- Created reusable dialog cards for login, registration, password reset, profile, password change and logout.
+- Documented the menu behaviour in README.
+- Ran pnpm lint in `fe` and npm run lint & npm test in `be`.

--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -13,7 +13,23 @@
             slim
             @click="toggleTheme"
           />
-          <v-btn icon="mdi-dots-vertical" />
+          <v-menu>
+            <template #activator="{ props }">
+              <v-btn v-bind="props" icon="mdi-dots-vertical" />
+            </template>
+            <v-list density="compact">
+              <template v-if="auth.loggedIn">
+                <v-list-item title="Profile" @click="showProfile = true" />
+                <v-list-item title="Change Password" @click="showChange = true" />
+                <v-list-item title="Logout" @click="showLogout = true" />
+              </template>
+              <template v-else>
+                <v-list-item title="Login" @click="showLogin = true" />
+                <v-list-item title="Register" @click="showRegister = true" />
+                <v-list-item title="Password Reset" @click="showReset = true" />
+              </template>
+            </v-list>
+          </v-menu>
         </template>
       </v-app-bar>
 
@@ -38,6 +54,25 @@
           <router-view />
         </v-container>
       </v-main>
+
+      <v-dialog v-model="showLogin" persistent>
+        <LoginCard @cancel="showLogin = false" @login="handleLogin" />
+      </v-dialog>
+      <v-dialog v-model="showRegister" persistent>
+        <RegisterCard @cancel="showRegister = false" @register="handleRegister" />
+      </v-dialog>
+      <v-dialog v-model="showReset" persistent>
+        <PasswordResetCard @cancel="showReset = false" @reset="handleReset" />
+      </v-dialog>
+      <v-dialog v-model="showChange" persistent>
+        <ChangePasswordCard @cancel="showChange = false" @change="handleChange" />
+      </v-dialog>
+      <v-dialog v-model="showLogout" persistent>
+        <LogoutCard @cancel="showLogout = false" @logout="handleLogout" />
+      </v-dialog>
+      <v-dialog v-model="showProfile" persistent>
+        <ProfileCard @cancel="showProfile = false" @save="handleProfile" />
+      </v-dialog>
     </v-app>
   </v-responsive>
 </template>
@@ -45,11 +80,29 @@
 <script lang="ts" setup>
   import { ref } from 'vue'
   import { useTheme } from 'vuetify'
+  import ChangePasswordCard from './components/ChangePasswordCard.vue'
+  import LoginCard from './components/LoginCard.vue'
+  import LogoutCard from './components/LogoutCard.vue'
+  import PasswordResetCard from './components/PasswordResetCard.vue'
+  import ProfileCard from './components/ProfileCard.vue'
+  import RegisterCard from './components/RegisterCard.vue'
+  import { useAuthStore } from './stores/auth'
 
   /**
    * Reactive state for the navigation drawer.
    */
   const drawer = ref(false)
+
+  /** Authentication store controlling login state. */
+  const auth = useAuthStore()
+
+  /** Dialog visibility flags for each action. */
+  const showLogin = ref(false)
+  const showRegister = ref(false)
+  const showReset = ref(false)
+  const showChange = ref(false)
+  const showLogout = ref(false)
+  const showProfile = ref(false)
 
   /**
    * Access Vuetify's theme instance so we can switch between light and dark
@@ -81,4 +134,37 @@
     { icon: 'mdi-book-open-page-variant-outline', title: 'References', subtitle: 'Manage reference data', to: '/references' },
     { icon: 'mdi-account-cog-outline', title: 'Users', subtitle: 'Manage system users', to: '/users' },
   ]
+
+  /** Handle login form submission. Simply mark the user as logged in. */
+  function handleLogin () {
+    auth.loggedIn = true
+    showLogin.value = false
+  }
+
+  /** Handle register form submission and mark the user as logged in. */
+  function handleRegister () {
+    auth.loggedIn = true
+    showRegister.value = false
+  }
+
+  /** Close the password reset dialog. */
+  function handleReset () {
+    showReset.value = false
+  }
+
+  /** Close the password change dialog. */
+  function handleChange () {
+    showChange.value = false
+  }
+
+  /** Handle logout confirmation. */
+  function handleLogout () {
+    auth.loggedIn = false
+    showLogout.value = false
+  }
+
+  /** Close the profile dialog after saving. */
+  function handleProfile () {
+    showProfile.value = false
+  }
 </script>

--- a/fe/src/components/ChangePasswordCard.vue
+++ b/fe/src/components/ChangePasswordCard.vue
@@ -1,0 +1,45 @@
+<template>
+  <v-card width="400">
+    <v-card-title>Change Password</v-card-title>
+    <v-card-text>
+      <v-text-field v-model="oldPass" label="Old Password" type="password" />
+      <v-text-field v-model="newPass" label="New Password" type="password" />
+      <v-text-field
+        v-model="confirm"
+        :error="confirm !== '' && !match"
+        :error-messages="confirm !== '' && !match ? 'Passwords do not match' : ''"
+        label="Confirm New Password"
+        type="password"
+      />
+    </v-card-text>
+    <v-card-actions>
+      <v-spacer />
+      <v-btn color="primary" :disabled="!match" @click="onChange">Change</v-btn>
+      <v-btn @click="$emit('cancel')">Cancel</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+  import { computed, ref } from 'vue'
+
+  /** Current password. */
+  const oldPass = ref('')
+  /** New password to set. */
+  const newPass = ref('')
+  /** Confirmation field for the new password. */
+  const confirm = ref('')
+
+  /** True when the new password and confirmation match. */
+  const match = computed(() => newPass.value !== '' && newPass.value === confirm.value)
+
+  const emit = defineEmits<{
+    (e: 'change', payload: { oldPassword: string, newPassword: string }): void
+    (e: 'cancel'): void
+  }>()
+
+  /** Emit the change event with the old and new password. */
+  function onChange () {
+    emit('change', { oldPassword: oldPass.value, newPassword: newPass.value })
+  }
+</script>

--- a/fe/src/components/LoginCard.vue
+++ b/fe/src/components/LoginCard.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-card width="400">
+    <v-card-title>Login</v-card-title>
+    <v-card-text>
+      <v-text-field v-model="email" label="Email" type="email" />
+      <v-text-field v-model="password" label="Password" type="password" />
+    </v-card-text>
+    <v-card-actions>
+      <v-spacer />
+      <v-btn color="primary" @click="onLogin">Login</v-btn>
+      <v-btn @click="$emit('cancel')">Cancel</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue'
+
+  /** Email address provided by the user. */
+  const email = ref('')
+  /** Password provided by the user. */
+  const password = ref('')
+
+  const emit = defineEmits<{
+    (e: 'login', payload: { email: string, password: string }): void
+    (e: 'cancel'): void
+  }>()
+
+  /** Emit the login event with the form data. */
+  function onLogin () {
+    emit('login', { email: email.value, password: password.value })
+  }
+</script>

--- a/fe/src/components/LogoutCard.vue
+++ b/fe/src/components/LogoutCard.vue
@@ -1,0 +1,18 @@
+<template>
+  <v-card width="300">
+    <v-card-title>Logout</v-card-title>
+    <v-card-text>Are you sure you want to logout?</v-card-text>
+    <v-card-actions>
+      <v-spacer />
+      <v-btn color="primary" @click="$emit('logout')">Logout</v-btn>
+      <v-btn @click="$emit('cancel')">Cancel</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+/** Emits logout or cancel actions. */
+  defineEmits<{
+    (e: 'logout' | 'cancel'): void
+  }>()
+</script>

--- a/fe/src/components/PasswordResetCard.vue
+++ b/fe/src/components/PasswordResetCard.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-card width="400">
+    <v-card-title>Password Reset</v-card-title>
+    <v-card-text>
+      <v-text-field v-model="email" label="Email" type="email" />
+    </v-card-text>
+    <v-card-actions>
+      <v-spacer />
+      <v-btn color="primary" @click="onReset">Reset</v-btn>
+      <v-btn @click="$emit('cancel')">Cancel</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue'
+
+  /** Email address for password reset. */
+  const email = ref('')
+
+  const emit = defineEmits<{
+    (e: 'reset', email: string): void
+    (e: 'cancel'): void
+  }>()
+
+  /** Emit the reset event with the provided email. */
+  function onReset () {
+    emit('reset', email.value)
+  }
+</script>

--- a/fe/src/components/ProfileCard.vue
+++ b/fe/src/components/ProfileCard.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-card width="400">
+    <v-card-title>Profile</v-card-title>
+    <v-card-text>
+      <v-text-field v-model="email" label="Email" type="email" />
+    </v-card-text>
+    <v-card-actions>
+      <v-spacer />
+      <v-btn color="primary" @click="onSave">Save</v-btn>
+      <v-btn @click="$emit('cancel')">Cancel</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue'
+
+  /** User email address. */
+  const email = ref('')
+
+  const emit = defineEmits<{
+    (e: 'save', email: string): void
+    (e: 'cancel'): void
+  }>()
+
+  /** Emit the save event when the form is submitted. */
+  function onSave () {
+    emit('save', email.value)
+  }
+</script>

--- a/fe/src/components/RegisterCard.vue
+++ b/fe/src/components/RegisterCard.vue
@@ -1,0 +1,45 @@
+<template>
+  <v-card width="400">
+    <v-card-title>Register</v-card-title>
+    <v-card-text>
+      <v-text-field v-model="email" label="Email" type="email" />
+      <v-text-field v-model="password" label="Password" type="password" />
+      <v-text-field
+        v-model="confirm"
+        :error="confirm !== '' && !match"
+        :error-messages="confirm !== '' && !match ? 'Passwords do not match' : ''"
+        label="Confirm Password"
+        type="password"
+      />
+    </v-card-text>
+    <v-card-actions>
+      <v-spacer />
+      <v-btn color="primary" :disabled="!match" @click="onRegister">Register</v-btn>
+      <v-btn @click="$emit('cancel')">Cancel</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+  import { computed, ref } from 'vue'
+
+  /** Email address for the new account. */
+  const email = ref('')
+  /** Password for the new account. */
+  const password = ref('')
+  /** Second password field to ensure they match. */
+  const confirm = ref('')
+
+  /** True when the password and confirmation match. */
+  const match = computed(() => password.value !== '' && password.value === confirm.value)
+
+  const emit = defineEmits<{
+    (e: 'register', payload: { email: string, password: string }): void
+    (e: 'cancel'): void
+  }>()
+
+  /** Emit the register event when the user submits the form. */
+  function onRegister () {
+    emit('register', { email: email.value, password: password.value })
+  }
+</script>

--- a/fe/src/stores/auth.ts
+++ b/fe/src/stores/auth.ts
@@ -1,0 +1,12 @@
+// Utilities
+import { defineStore } from 'pinia'
+
+/**
+ * Store managing authentication state.
+ */
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    /** Indicates if a user is currently authenticated. */
+    loggedIn: false,
+  }),
+})


### PR DESCRIPTION
## Summary
- add Pinia auth store
- add menu with login & profile entries based on auth state
- add dialog components for login, register, password reset, change password, logout and profile
- document the new menu in README
- log work for today

## Testing
- `pnpm lint` in `fe`
- `npm run lint` in `be`
- `npm test` in `be`


------
https://chatgpt.com/codex/tasks/task_e_684c44a09c988325a237ae66ad4d04be