### PR TITLE
Position auth dialogs below navbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Test database files
+be/tests/*.json

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The back end reads settings using the [`config`](https://www.npmjs.com/package/c
 ## Examples
 After running the development server, open `http://localhost:3000` in your browser. The navigation drawer links (Home, People, Teams, Tasks, Budget, References, and Users) each lead to a dedicated page that you can further extend. Edit components in `src/` to continue customizing the application.
 
-The app bar contains a triple-dot menu that adapts based on authentication state. When logged out it offers **Login**, **Register**, and **Password Reset** actions. Once logged in the menu switches to **Profile**, **Change Password**, and **Logout**.
+The app bar contains a triple-dot menu that adapts based on authentication state. When logged out it offers **Login**, **Register**, and **Password Reset** actions. Once logged in the menu switches to **Profile**, **Change Password**, and **Logout**. Authentication dialogs now appear below the navigation bar on the top-right of the page.
 
 For the API you can send the following query using `curl` or a GraphQL client. You can also override configuration values on the fly:
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -50,3 +50,7 @@
 - Created reusable dialog cards for login, registration, password reset, profile, password change and logout.
 - Documented the menu behaviour in README.
 - Ran pnpm lint in `fe` and npm run lint & npm test in `be`.
+2025-06-13
+- Adjusted authentication dialogs to open below the app bar on the top-right.
+- Documented UI change in README.
+- Ran pnpm lint in `fe` and npm run lint & npm test in `be`.

--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -6,7 +6,7 @@
           <!-- Navigation drawer toggle -->
           <v-app-bar-nav-icon @click.stop="drawer = !drawer" />
         </template>
-        <v-app-bar-title >Fulcrum</v-app-bar-title>
+        <v-app-bar-title>Fulcrum</v-app-bar-title>
         <template #append>
           <v-btn
             :icon="vuetifyTheme.global.current.value.dark ? 'mdi-weather-night' : 'mdi-weather-sunny'"
@@ -55,22 +55,47 @@
         </v-container>
       </v-main>
 
-      <v-dialog v-model="showLogin" persistent>
+      <!-- Authentication dialogs positioned under the top-right navbar -->
+      <v-dialog
+        v-model="showLogin"
+        location="top right"
+        persistent
+      >
         <LoginCard @cancel="showLogin = false" @login="handleLogin" />
       </v-dialog>
-      <v-dialog v-model="showRegister" persistent>
+      <v-dialog
+        v-model="showRegister"
+        location="top right"
+        persistent
+      >
         <RegisterCard @cancel="showRegister = false" @register="handleRegister" />
       </v-dialog>
-      <v-dialog v-model="showReset" persistent>
+      <v-dialog
+        v-model="showReset"
+        location="top right"
+        persistent
+      >
         <PasswordResetCard @cancel="showReset = false" @reset="handleReset" />
       </v-dialog>
-      <v-dialog v-model="showChange" persistent>
+      <v-dialog
+        v-model="showChange"
+        location="top right"
+        persistent
+      >
         <ChangePasswordCard @cancel="showChange = false" @change="handleChange" />
       </v-dialog>
-      <v-dialog v-model="showLogout" persistent>
+      <v-dialog
+        v-model="showLogout"
+        location="top right"
+        persistent
+      >
         <LogoutCard @cancel="showLogout = false" @logout="handleLogout" />
       </v-dialog>
-      <v-dialog v-model="showProfile" persistent>
+      <v-dialog
+        v-model="showProfile"
+        location="top right"
+        persistent
+      >
         <ProfileCard @cancel="showProfile = false" @save="handleProfile" />
       </v-dialog>
     </v-app>

--- a/fe/src/plugins/vuetify.ts
+++ b/fe/src/plugins/vuetify.ts
@@ -4,13 +4,13 @@
  * Framework documentation: https://vuetifyjs.com`
  */
 
+// https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
+import { createVuetify } from 'vuetify'
+
 // Styles
 import '@mdi/font/css/materialdesignicons.css'
 
 import 'vuetify/styles'
-
-// https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
-import { createVuetify } from 'vuetify'
 
 const vuetify = createVuetify({
   theme: {
@@ -18,8 +18,8 @@ const vuetify = createVuetify({
     themes: {
       light: {
         colors: {
-          background: '#edefe6',
-          surface: '#f9faf1',
+          'background': '#edefe6',
+          'surface': '#f9faf1',
           'surface-dim': '#d9dbd2',
           'surface-bright': '#f9faf1',
           'surface-container-lowest': '#ffffff',
@@ -30,22 +30,22 @@ const vuetify = createVuetify({
           'on-surface': '#1a1c17',
           'inverse-surface': '#2f312c',
           'inverse-on-surface': '#f0f1e9',
-          outline: '#73796c',
+          'outline': '#73796c',
           'outline-variant': '#c2c9ba',
-          primary: '#40682c',
+          'primary': '#40682c',
           'on-primary': '#ffffff',
           'primary-container': '#c0f0a4',
           'on-primary-container': '#072100',
           'inverse-primary': '#a5d48a',
-          secondary: '#656104',
+          'secondary': '#656104',
           'on-secondary': '#ffffff',
           'secondary-container': '#ece681',
           'on-secondary-container': '#1e1c00',
-          tertiary: '#006c4f',
+          'tertiary': '#006c4f',
           'on-tertiary': '#ffffff',
           'tertiary-container': '#9df4cf',
           'on-tertiary-container': '#002116',
-          error: '#ba1a1a',
+          'error': '#ba1a1a',
           'on-error': '#ffffff',
           'error-container': '#ffdad6',
           'on-error-container': '#410002',
@@ -70,8 +70,8 @@ const vuetify = createVuetify({
       },
       dark: {
         colors: {
-          background: '#1e201b',
-          surface: '#11140f',
+          'background': '#1e201b',
+          'surface': '#11140f',
           'surface-dim': '#11140f',
           'surface-bright': '#373a34',
           'surface-container-lowest': '#0c0f0a',
@@ -82,22 +82,22 @@ const vuetify = createVuetify({
           'on-surface': '#e2e3db',
           'inverse-surface': '#e2e3db',
           'inverse-on-surface': '#2f312c',
-          outline: '#8c9385',
+          'outline': '#8c9385',
           'outline-variant': '#42493d',
-          primary: '#a5d48a',
+          'primary': '#a5d48a',
           'on-primary': '#113801',
           'primary-container': '#285016',
           'on-primary-container': '#c0f0a4',
           'inverse-primary': '#40682c',
-          secondary: '#d0ca69',
+          'secondary': '#d0ca69',
           'on-secondary': '#343200',
           'secondary-container': '#4c4900',
           'on-secondary-container': '#ece681',
-          tertiary: '#82d7b4',
+          'tertiary': '#82d7b4',
           'on-tertiary': '#003827',
           'tertiary-container': '#00513b',
           'on-tertiary-container': '#9df4cf',
-          error: '#ffb4ab',
+          'error': '#ffb4ab',
           'on-error': '#690005',
           'error-container': '#93000a',
           'on-error-container': '#ffb4ab',
@@ -126,4 +126,3 @@ const vuetify = createVuetify({
 })
 
 export default vuetify
-


### PR DESCRIPTION
## Summary
- update UI so authentication dialogs open in the top-right below the app bar
- document new behavior in README
- log work on the change and ignore test DB files
- autoformat Vuetify plugin via ESLint

## Testing
- `pnpm lint`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c463cea448325b9d4e085d505301a