### PR TITLE
Add user CRUD and optional profile fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Bumasys Alfa
 
 ## Project Overview
+
 Bumasys Alfa is a full-stack scaffold featuring a Vuetify powered Vue front end and a TypeScript powered Express/Apollo GraphQL back end. It provides a minimal setup to experiment with Vuetify 3 and GraphQL based authentication.
 
 ## Installation Instructions
+
 Use [pnpm](https://pnpm.io/) to install dependencies for the front end and npm for the back end:
 
 ```bash
@@ -19,11 +21,13 @@ npm install
 ```
 
 ## Usage Guide
+
 Start a development server with hot reloading:
 
 ```bash
 pnpm dev
 ```
+
 The dev server proxies GraphQL requests on `/graphql` to `http://localhost:4000`,
 so make sure the back end is running during development.
 
@@ -48,9 +52,11 @@ pnpm build
 ```
 
 ## Configuration
+
 The back end reads settings using the [`config`](https://www.npmjs.com/package/config) library. Default values live in `be/config/default.json`. Create additional JSON files in that directory or use environment variables to override the defaults. The environment variable mapping is defined in `be/config/custom-environment-variables.json` and supports `PORT`, `JWT_SECRET`, and `DB_FILE`.
 
 ## Examples
+
 After running the development server, open `http://localhost:3000` in your browser. The navigation drawer links (Home, People, Teams, Tasks, Budget, References, and Users) each lead to a dedicated page that you can further extend. Edit components in `src/` to continue customizing the application.
 
 The app bar contains a triple-dot menu that adapts based on authentication state. When logged out it offers **Login**, **Register**, and **Password Reset** actions. Once logged in the menu switches to **Profile**, **Change Password**, and **Logout**. Authentication dialogs now appear below the navigation bar on the top-right of the page.
@@ -65,7 +71,10 @@ Then send the following query using `curl` or a GraphQL client:
 
 ```graphql
 query {
-  me { id email }
+  me {
+    id
+    email
+  }
 }
 ```
 
@@ -85,10 +94,16 @@ Authentication mutations return both a short-lived access token and a long-lived
 to obtain a new access token. Call `logout` with the refresh token to invalidate
 it.
 
+Authenticated clients can manage users via the `users`, `user`, `createUser`,
+`updateUser`, and `deleteUser` operations. User records include optional
+`firstName`, `lastName`, and `note` fields in addition to `email`.
+
 ## Contributing Guidelines
+
 1. Fork the repository and create feature branches for your work.
 2. Run `pnpm run lint` in `fe` and `npm run lint` in `be` before opening a pull request.
 3. Follow conventional commit messages for clarity.
 
 ## License
+
 This project is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,56 +1,62 @@
 2025-06-13
+
 - Added navigation drawer toggle and theme switcher in App.vue.
 - Updated README with project sections.
 - Created WORKLOG to track development actions.
 - Fixed ESLint warnings in router configuration.
-2025-06-13
+  2025-06-13
 - Implemented mock navigation items with icons and descriptions in the navigation drawer.
 - Ran pnpm lint and type-check to ensure code quality.
-2025-06-13
+  2025-06-13
 - Added Express/Apollo backend with JWT auth skeleton and tests.
 - Integrated ESLint, Prettier, Jest and Supertest.
 - Updated README with backend instructions.
-2025-06-13
+  2025-06-13
 - Added dedicated pages for all navigation drawer items and updated the drawer links.
 - Introduced Home item leading to the main page.
 - Updated README examples section and ran pnpm lint and type-check.
-2025-06-13
+  2025-06-13
 - Migrated backend to TypeScript and upgraded to @apollo/server.
 - Updated eslint to handle TS and added ts-jest configuration.
 - Adjusted README with TypeScript instructions.
 - Ran npm run lint and npm test to ensure code quality.
-2025-06-13
+  2025-06-13
 - Replaced deprecated body-parser usage with express.json in the backend.
 - Installed dependencies and executed npm run lint and npm test.
 - Installed front-end dependencies and ran pnpm lint to verify.
-2025-06-13
+  2025-06-13
 - Switched backend configuration to use node-config with JSON files in be/config.
 - Updated tests and README accordingly.
 - Ran npm run lint and npm test to verify.
-2025-06-13
+  2025-06-13
 - Implemented refresh tokens and logout invalidation in backend.
 - Added unit tests for refresh and logout.
 - Updated README with refresh token usage.
 - Added environment variable override mapping and related tests.
 - Updated README with override instructions.
 - Ran npm run lint and npm test.
-2025-06-13
+  2025-06-13
 - Added health GraphQL query and resolver returning readiness state.
 - Documented usage in README and added health tests.
 - Ran npm install, lint and tests.
-2025-06-13
+  2025-06-13
 - Configured Vite dev server proxy to backend GraphQL on port 4000.
 - Updated README with proxy note.
 - Ran pnpm install, lint, and npm install, lint, test.
 - Display backend readiness in the front-end footer using the health query.
 - Updated README with footer description.
 - Ran pnpm lint, npm run lint and npm test.
-2025-06-13
+  2025-06-13
 - Added authentication menu with two states using Pinia.
 - Created reusable dialog cards for login, registration, password reset, profile, password change and logout.
 - Documented the menu behaviour in README.
 - Ran pnpm lint in `fe` and npm run lint & npm test in `be`.
-2025-06-13
+  2025-06-13
 - Adjusted authentication dialogs to open below the app bar on the top-right.
 - Documented UI change in README.
 - Ran pnpm lint in `fe` and npm run lint & npm test in `be`.
+  2025-06-13
+- Added optional firstName, lastName and note fields to user model and implemented authenticated CRUD GraphQL operations.
+- Wrote unit tests covering user CRUD operations.
+- Updated README with new user fields and CRUD operation summary.
+- Ran npm lint and test to ensure quality.

--- a/be/src/db.ts
+++ b/be/src/db.ts
@@ -3,7 +3,14 @@ import path from 'path';
 
 export interface Database {
   data: {
-    users: Array<{ id: string; email: string; password: string }>;
+    users: Array<{
+      id: string;
+      email: string;
+      password: string;
+      firstName?: string;
+      lastName?: string;
+      note?: string;
+    }>;
   };
   write(): Promise<void>;
 }

--- a/be/src/schema.ts
+++ b/be/src/schema.ts
@@ -16,6 +16,9 @@ export const typeDefs = gql`
   type User {
     id: ID!
     email: String!
+    firstName: String
+    lastName: String
+    note: String
   }
 
   type AuthPayload {
@@ -27,12 +30,36 @@ export const typeDefs = gql`
   type Query {
     me: User
     health: Boolean!
+    users: [User!]!
+    user(id: ID!): User
   }
 
   type Mutation {
-    register(email: String!, password: String!): AuthPayload!
+    register(
+      email: String!
+      password: String!
+      firstName: String
+      lastName: String
+      note: String
+    ): AuthPayload!
     login(email: String!, password: String!): AuthPayload!
     changePassword(oldPassword: String!, newPassword: String!): Boolean!
+    createUser(
+      email: String!
+      password: String!
+      firstName: String
+      lastName: String
+      note: String
+    ): User!
+    updateUser(
+      id: ID!
+      email: String
+      password: String
+      firstName: String
+      lastName: String
+      note: String
+    ): User!
+    deleteUser(id: ID!): Boolean!
     logout(refreshToken: String!): Boolean!
     refreshToken(refreshToken: String!): AuthPayload!
     resetPassword(email: String!): Boolean!
@@ -48,21 +75,56 @@ export const resolvers = {
       { user }: { user?: { id: string; email: string } },
     ) => user || null,
     health: () => Boolean(db),
+    users: (_: unknown, __: unknown, { user }: { user?: { id: string } }) => {
+      if (!user) throw new Error('Unauthenticated');
+      return db.data.users.map(({ password, ...rest }) => rest);
+    },
+    user: (
+      _: unknown,
+      { id }: { id: string },
+      { user }: { user?: { id: string } },
+    ) => {
+      if (!user) throw new Error('Unauthenticated');
+      const found = db.data.users.find((u) => u.id === id);
+      if (!found) return null;
+      const { password, ...rest } = found;
+      return rest;
+    },
   },
   Mutation: {
     async register(
       _: unknown,
-      { email, password }: { email: string; password: string },
+      {
+        email,
+        password,
+        firstName,
+        lastName,
+        note,
+      }: {
+        email: string;
+        password: string;
+        firstName?: string;
+        lastName?: string;
+        note?: string;
+      },
     ) {
       const exists = db.data.users.find((u) => u.email === email);
       if (exists) throw new Error('Email in use');
       const hash = await hashPassword(password);
-      const user = { id: Date.now().toString(), email, password: hash };
+      const user = {
+        id: Date.now().toString(),
+        email,
+        password: hash,
+        firstName,
+        lastName,
+        note,
+      };
       db.data.users.push(user);
       await db.write();
       const token = signToken(user.id);
       const refreshToken = signRefreshToken(user.id);
-      return { token, refreshToken, user: { id: user.id, email: user.email } };
+      const { password: _p, ...rest } = user;
+      return { token, refreshToken, user: rest };
     },
     async login(
       _: unknown,
@@ -74,7 +136,8 @@ export const resolvers = {
       if (!valid) throw new Error('Invalid credentials');
       const token = signToken(user.id);
       const refreshToken = signRefreshToken(user.id);
-      return { token, refreshToken, user: { id: user.id, email: user.email } };
+      const { password: _p, ...rest } = user;
+      return { token, refreshToken, user: rest };
     },
     async changePassword(
       _: unknown,
@@ -92,6 +155,83 @@ export const resolvers = {
       await db.write();
       return true;
     },
+    async createUser(
+      _: unknown,
+      {
+        email,
+        password,
+        firstName,
+        lastName,
+        note,
+      }: {
+        email: string;
+        password: string;
+        firstName?: string;
+        lastName?: string;
+        note?: string;
+      },
+      { user }: { user?: { id: string } },
+    ) {
+      if (!user) throw new Error('Unauthenticated');
+      const exists = db.data.users.find((u) => u.email === email);
+      if (exists) throw new Error('Email in use');
+      const hash = await hashPassword(password);
+      const newUser = {
+        id: Date.now().toString(),
+        email,
+        password: hash,
+        firstName,
+        lastName,
+        note,
+      };
+      db.data.users.push(newUser);
+      await db.write();
+      const { password: _p, ...rest } = newUser;
+      return rest;
+    },
+    async updateUser(
+      _: unknown,
+      {
+        id,
+        email,
+        password,
+        firstName,
+        lastName,
+        note,
+      }: {
+        id: string;
+        email?: string;
+        password?: string;
+        firstName?: string;
+        lastName?: string;
+        note?: string;
+      },
+      { user }: { user?: { id: string } },
+    ) {
+      if (!user) throw new Error('Unauthenticated');
+      const existing = db.data.users.find((u) => u.id === id);
+      if (!existing) throw new Error('User not found');
+      if (email !== undefined) existing.email = email;
+      if (password !== undefined)
+        existing.password = await hashPassword(password);
+      if (firstName !== undefined) existing.firstName = firstName;
+      if (lastName !== undefined) existing.lastName = lastName;
+      if (note !== undefined) existing.note = note;
+      await db.write();
+      const { password: _pw, ...rest } = existing;
+      return rest;
+    },
+    deleteUser(
+      _: unknown,
+      { id }: { id: string },
+      { user }: { user?: { id: string } },
+    ) {
+      if (!user) throw new Error('Unauthenticated');
+      const index = db.data.users.findIndex((u) => u.id === id);
+      if (index === -1) return false;
+      db.data.users.splice(index, 1);
+      return db.write().then(() => true);
+    },
     logout: (_: unknown, { refreshToken }: { refreshToken: string }) => {
       invalidateRefreshToken(refreshToken);
       return true;
@@ -103,10 +243,11 @@ export const resolvers = {
       if (!user) throw new Error('Invalid refresh token');
       const token = signToken(user.id);
       const newRefresh = signRefreshToken(user.id);
+      const { password: _pw, ...rest } = user;
       return {
         token,
         refreshToken: newRefresh,
-        user: { id: user.id, email: user.email },
+        user: rest,
       };
     },
     resetPassword: async (_: unknown, { email }: { email: string }) => {

--- a/be/tests/user-crud.test.ts
+++ b/be/tests/user-crud.test.ts
@@ -1,0 +1,65 @@
+import type { Application } from 'express';
+import request from 'supertest';
+import { createApp } from '../src/index';
+import fs from 'fs';
+import path from 'path';
+
+let app: Application;
+
+beforeAll(async () => {
+  const dbFile = path.join(__dirname, 'crud-db.json');
+  if (fs.existsSync(dbFile)) fs.unlinkSync(dbFile);
+  const config = require('../src/config').default;
+  config.dbFile = dbFile;
+  ({ app } = await createApp());
+});
+
+describe('User CRUD', () => {
+  test('requires auth', async () => {
+    const res = await request(app).post('/graphql').send({
+      query: `query { users { id } }`,
+    });
+    expect(res.body.errors[0].message).toBe('Unauthenticated');
+  });
+
+  test('create update delete', async () => {
+    const reg = await request(app).post('/graphql').send({
+      query: `mutation { register(email: "main@example.com", password: "p") { token } }`,
+    });
+    const token = reg.body.data.register.token;
+
+    const auth = { Authorization: `Bearer ${token}` };
+
+    const create = await request(app).post('/graphql').set(auth).send({
+      query: `mutation { createUser(email: "u@example.com", password: "pass", firstName: "F", lastName: "L", note: "N") { id firstName lastName note } }`,
+    });
+    const id = create.body.data.createUser.id;
+    expect(create.body.data.createUser.firstName).toBe('F');
+
+    const update = await request(app)
+      .post('/graphql')
+      .set(auth)
+      .send({
+        query: `mutation { updateUser(id: "${id}", note: "Updated") { note } }`,
+      });
+    expect(update.body.data.updateUser.note).toBe('Updated');
+
+    const list = await request(app)
+      .post('/graphql')
+      .set(auth)
+      .send({ query: `query { users { id } }` });
+    expect(list.body.data.users.length).toBe(2);
+
+    const del = await request(app)
+      .post('/graphql')
+      .set(auth)
+      .send({ query: `mutation { deleteUser(id: "${id}") }` });
+    expect(del.body.data.deleteUser).toBe(true);
+
+    const listAfter = await request(app)
+      .post('/graphql')
+      .set(auth)
+      .send({ query: `query { users { id } }` });
+    expect(listAfter.body.data.users.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- extend database model to include optional `firstName`, `lastName` and `note`
- update GraphQL schema with user CRUD operations guarded by authentication
- implement resolvers for new operations and enhanced register/login
- add unit tests for user CRUD flow
- update docs with new operations
- log work in WORKLOG

## Testing
- `npm -C be run lint`
- `npm -C be test`

------
https://chatgpt.com/codex/tasks/task_e_684c471fd3588325a44be9bb4b3c1705