### PR TITLE
Fix auth signing types

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -60,3 +60,7 @@
 - Wrote unit tests covering user CRUD operations.
 - Updated README with new user fields and CRUD operation summary.
 - Ran npm lint and test to ensure quality.
+  2025-06-13
+- Fixed TypeScript type errors in backend auth token generation.
+- Cast JWT expiration config values to ms.StringValue and adjusted imports.
+- Ran npm lint and tests successfully after patch.

--- a/be/src/auth.ts
+++ b/be/src/auth.ts
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken';
+import type { StringValue } from 'ms';
 import bcrypt from 'bcryptjs';
 import config from './config';
 
@@ -11,7 +12,9 @@ const refreshTokens = new Set<string>();
  * @returns Signed JWT
  */
 export function signToken(id: string): string {
-  return jwt.sign({ id }, config.jwtSecret as string, { expiresIn: config.expiresIn as string});
+  return jwt.sign({ id }, config.jwtSecret, {
+    expiresIn: config.expiresIn as StringValue,
+  });
 }
 
 /**
@@ -20,7 +23,9 @@ export function signToken(id: string): string {
  * @returns Signed refresh JWT
  */
 export function signRefreshToken(id: string): string {
-  const token = jwt.sign({ id }, config.jwtSecret as string, { expiresIn: config.refreshExpiresIn as string });
+  const token = jwt.sign({ id }, config.jwtSecret, {
+    expiresIn: config.refreshExpiresIn as StringValue,
+  });
   refreshTokens.add(token);
   return token;
 }


### PR DESCRIPTION
## Summary
- fix token signing by casting expiration to `StringValue`
- log auth.ts fix in WORKLOG

## Testing
- `npm run lint` in `be`
- `npm test` in `be`


------
https://chatgpt.com/codex/tasks/task_e_684c50195920832598e9a5d366d34320