### PR TITLE
Implement footer user info and snackbar alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The back end reads settings using the [`config`](https://www.npmjs.com/package/c
 
 After running the development server, open `http://localhost:3000` in your browser. The navigation drawer links (Home, People, Teams, Tasks, Budget, References, and Users) each lead to a dedicated page that you can further extend. Edit components in `src/` to continue customizing the application.
 
-The app bar contains a triple-dot menu that adapts based on authentication state. When logged out it offers **Login**, **Register**, and **Password Reset** actions. Once logged in the menu switches to **Profile**, **Change Password**, and **Logout**. Authentication dialogs now appear below the navigation bar on the top-right of the page and submit requests to the GraphQL API for all authentication operations.
+The app bar contains a triple-dot menu that adapts based on authentication state. When logged out it offers **Login**, **Register**, and **Password Reset** actions. Once logged in the menu switches to **Profile**, **Change Password**, and **Logout**. Authentication dialogs now appear below the navigation bar on the top-right of the page and submit requests to the GraphQL API for all authentication operations. User actions in these dialogs show success or error notifications via snackbars.
 
 For the API you can send the following query using `curl` or a GraphQL client. You can also override configuration values on the fly:
 
@@ -87,7 +87,8 @@ query {
 ```
 
 The Vue application automatically checks this endpoint on load and shows the
-backend status in the footer.
+backend status in the footer. When logged in, the footer also displays the
+authenticated user's name and email.
 
 Authentication mutations return both a short-lived access token and a long-lived
 `refreshToken`. Use the `refreshToken` mutation with the provided refresh token

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -64,8 +64,12 @@
 - Fixed TypeScript type errors in backend auth token generation.
 - Cast JWT expiration config values to ms.StringValue and adjusted imports.
 - Ran npm lint and tests successfully after patch.
-2025-06-13
+ 2025-06-13
 - Connected frontend authentication dialogs to backend GraphQL services using fetch-based API helpers.
 - Added auth store fields for tokens and user data.
 - Updated README with note about dialogs communicating with the API.
 - Adjusted config environment test secret length to pass validation.
+2025-06-13
+- Displayed authenticated user's name and email in the footer.
+- Added snackbar notifications for all authentication dialogs.
+- Ran pnpm install and lint in `fe`, npm install, lint and tests in `be`.

--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -98,6 +98,9 @@
       >
         <ProfileCard @cancel="showProfile = false" @save="handleProfile" />
       </v-dialog>
+      <v-snackbar v-model="snackbar" :color="snackbarColor" location="bottom" timeout="4000">
+        {{ snackbarMessage }}
+      </v-snackbar>
     </v-app>
   </v-responsive>
 </template>
@@ -113,6 +116,16 @@
   import RegisterCard from './components/RegisterCard.vue'
   import * as authApi from './services/auth'
   import { useAuthStore } from './stores/auth'
+
+  const snackbar = ref(false)
+  const snackbarMessage = ref('')
+  const snackbarColor = ref<'success' | 'error'>('success')
+
+  function notify (message: string, success = true) {
+    snackbarMessage.value = message
+    snackbarColor.value = success ? 'success' : 'error'
+    snackbar.value = true
+  }
 
   /**
    * Reactive state for the navigation drawer.
@@ -166,8 +179,10 @@
     try {
       const { login } = await authApi.login(payload.email, payload.password)
       auth.setAuth(login)
+      notify('Login successful')
     } catch (error) {
       console.error(error)
+      notify((error as Error).message, false)
     } finally {
       showLogin.value = false
     }
@@ -178,8 +193,10 @@
     try {
       const { register } = await authApi.register(payload.email, payload.password)
       auth.setAuth(register)
+      notify('Registration successful')
     } catch (error) {
       console.error(error)
+      notify((error as Error).message, false)
     } finally {
       showRegister.value = false
     }
@@ -189,8 +206,10 @@
   async function handleReset (email: string) {
     try {
       await authApi.resetPassword(email)
+      notify('Password reset email sent')
     } catch (error) {
       console.error(error)
+      notify((error as Error).message, false)
     } finally {
       showReset.value = false
     }
@@ -200,8 +219,10 @@
   async function handleChange (payload: { oldPassword: string, newPassword: string }) {
     try {
       await authApi.changePassword(payload.oldPassword, payload.newPassword)
+      notify('Password changed')
     } catch (error) {
       console.error(error)
+      notify((error as Error).message, false)
     } finally {
       showChange.value = false
     }
@@ -211,8 +232,10 @@
   async function handleLogout () {
     try {
       if (auth.refreshToken) await authApi.logout(auth.refreshToken)
+      notify('Logged out')
     } catch (error) {
       console.error(error)
+      notify((error as Error).message, false)
     } finally {
       auth.clearAuth()
       showLogout.value = false

--- a/fe/src/components/AppFooter.vue
+++ b/fe/src/components/AppFooter.vue
@@ -27,13 +27,18 @@
       </span>
       &nbsp;|&nbsp;© {{ (new Date()).getFullYear() }}
       <span class="d-none d-sm-inline-block">Radek Zitek</span>
+      <template v-if="userSummary">
+        &nbsp;|&nbsp;Logged in as {{ userSummary }}
+      </template>
 
     </div>
   </v-footer>
 </template>
 
 <script setup lang="ts">
-  import { onMounted, ref } from 'vue'
+  import { storeToRefs } from 'pinia'
+  import { computed, onMounted, ref } from 'vue'
+  import { useAuthStore } from '../stores/auth'
 
   const items = [
     {
@@ -45,6 +50,17 @@
 
   /** Indicates whether the backend server is ready. */
   const ready = ref<boolean | null>(null)
+
+  /** Authentication store for user details */
+  const auth = useAuthStore()
+  const { user } = storeToRefs(auth)
+
+  /** Display name and email for authenticated user */
+  const userSummary = computed(() => {
+    if (!user.value) return ''
+    const name = [user.value.firstName, user.value.lastName].filter(Boolean).join(' ').trim()
+    return name ? `${name} (${user.value.email})` : user.value.email
+  })
 
   /**
    * Query the backend health endpoint and update the readiness state.


### PR DESCRIPTION
## Summary
- show current user's name and email in the footer
- add snackbar notifications for authentication dialogs
- document new behaviour in README
- log work in WORKLOG

## Testing
- `pnpm lint`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c7133de6c8325880cb62bdedb1e3c