### PR TITLE
Implement editable profile card

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The back end reads settings using the [`config`](https://www.npmjs.com/package/c
 
 After running the development server, open `http://localhost:3000` in your browser. The navigation drawer links (Home, People, Teams, Tasks, Budget, References, and Users) each lead to a dedicated page that you can further extend. Edit components in `src/` to continue customizing the application.
 
-The app bar contains a triple-dot menu that adapts based on authentication state. When logged out it offers **Login**, **Register**, and **Password Reset** actions. Once logged in the menu switches to **Profile**, **Change Password**, and **Logout**. Authentication dialogs now appear below the navigation bar on the top-right of the page and submit requests to the GraphQL API for all authentication operations. User actions in these dialogs show success or error notifications via snackbars.
+The app bar contains a triple-dot menu that adapts based on authentication state. When logged out it offers **Login**, **Register**, and **Password Reset** actions. Once logged in the menu switches to **Profile**, **Change Password**, and **Logout**. Authentication dialogs now appear below the navigation bar on the top-right of the page and submit requests to the GraphQL API for all authentication operations. User actions in these dialogs show success or error notifications via snackbars. The **Profile** dialog lets users edit their first and last name as well as a note while the email field is read-only.
 
 For the API you can send the following query using `curl` or a GraphQL client. You can also override configuration values on the fly:
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -73,3 +73,8 @@
 - Displayed authenticated user's name and email in the footer.
 - Added snackbar notifications for all authentication dialogs.
 - Ran pnpm install and lint in `fe`, npm install, lint and tests in `be`.
+2025-06-13
+- Implemented profile editing dialog with first/last name and note fields.
+- Added updateUser API call and wired it in App.vue.
+- Documented profile editing in README.
+- Ran pnpm lint and npm test to verify.

--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -242,8 +242,25 @@
     }
   }
 
-  /** Close the profile dialog after saving. */
-  function handleProfile () {
-    showProfile.value = false
+  /**
+   * Save the user's profile changes via the GraphQL API and close the dialog.
+   */
+  async function handleProfile (payload: { firstName: string, lastName: string, note: string }) {
+    if (!auth.user) return
+    try {
+      const { updateUser } = await authApi.updateUser(
+        auth.user.id,
+        payload.firstName,
+        payload.lastName,
+        payload.note,
+      )
+      auth.user = updateUser
+      notify('Profile updated')
+    } catch (error) {
+      console.error(error)
+      notify((error as Error).message, false)
+    } finally {
+      showProfile.value = false
+    }
   }
 </script>

--- a/fe/src/components/ProfileCard.vue
+++ b/fe/src/components/ProfileCard.vue
@@ -1,30 +1,49 @@
 <template>
   <v-card width="400">
-    <v-card-title>Profile</v-card-title>
-    <v-card-text>
-      <v-text-field v-model="email" label="Email" type="email" />
-    </v-card-text>
-    <v-card-actions>
-      <v-spacer />
-      <v-btn color="primary" @click="onSave">Save</v-btn>
-      <v-btn @click="$emit('cancel')">Cancel</v-btn>
-    </v-card-actions>
+    <form @submit.prevent="onSave">
+      <v-card-title>Profile</v-card-title>
+      <v-card-text>
+        <v-text-field v-model="firstName" label="First Name" />
+        <v-text-field v-model="lastName" label="Last Name" />
+        <v-text-field v-model="note" label="Note" />
+        <v-text-field v-model="email" label="Email" readonly type="email" />
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn color="primary" type="submit">Save</v-btn>
+        <v-btn type="button" @click="$emit('cancel')">Cancel</v-btn>
+      </v-card-actions>
+    </form>
   </v-card>
 </template>
 
 <script setup lang="ts">
   import { ref } from 'vue'
+  import { useAuthStore } from '../stores/auth'
+
+  /** Auth store to prefill user information. */
+  const auth = useAuthStore()
 
   /** User email address. */
-  const email = ref('')
+  const email = ref(auth.user?.email ?? '')
+  /** User first name. */
+  const firstName = ref(auth.user?.firstName ?? '')
+  /** User last name. */
+  const lastName = ref(auth.user?.lastName ?? '')
+  /** Optional user note. */
+  const note = ref(auth.user?.note ?? '')
 
   const emit = defineEmits<{
-    (e: 'save', email: string): void
+    (e: 'save', payload: { firstName: string, lastName: string, note: string }): void
     (e: 'cancel'): void
   }>()
 
-  /** Emit the save event when the form is submitted. */
+  /** Emit the save event with updated profile fields. */
   function onSave () {
-    emit('save', email.value)
+    emit('save', {
+      firstName: firstName.value,
+      lastName: lastName.value,
+      note: note.value,
+    })
   }
 </script>

--- a/fe/src/services/auth.ts
+++ b/fe/src/services/auth.ts
@@ -102,3 +102,26 @@ export function refresh (refreshToken: string) {
     { token: refreshToken },
   )
 }
+
+/** Update the authenticated user's profile fields. */
+export function updateUser (
+  id: string,
+  firstName: string,
+  lastName: string,
+  note: string,
+) {
+  const store = useAuthStore()
+  return graphql<{ updateUser: User }>(
+    `mutation($id: ID!, $firstName: String, $lastName: String, $note: String) {
+      updateUser(id: $id, firstName: $firstName, lastName: $lastName, note: $note) {
+        id
+        email
+        firstName
+        lastName
+        note
+      }
+    }`,
+    { id, firstName, lastName, note },
+    store.token,
+  )
+}


### PR DESCRIPTION
## Summary
- allow editing profile first/last name and note
- update profile API call and hook up to dialog
- document profile editing
- update work log

## Testing
- `pnpm lint`
- `pnpm type-check`
- `npm run lint -- --fix`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c7638712483258403a0bcd2ad0958